### PR TITLE
Set default error reporting

### DIFF
--- a/unix/src/exec.in
+++ b/unix/src/exec.in
@@ -42,7 +42,7 @@ if [ "" = "$USE_XP" ] ; then
   exit 255
 fi
 
-args="-C${ifs}-q${ifs}-dinclude_path=\".$PATHSEP$USE_XP$PATHSEP$PATHSEP$INCLUDE\"${ifs}-dmagic_quotes_gpc=0$RT_ARG"
+args="-C${ifs}-q${ifs}-dinclude_path=\".$PATHSEP$USE_XP$PATHSEP$PATHSEP$INCLUDE\"${ifs}-dmagic_quotes_gpc=0${ifs}-ddisplay_errors=stderr$RT_ARG"
 tool=$(locate "$USE_XP" "tools/"${RUNNER}".php" 1)
 #ifdef __BSD
 if [ ! -d /proc/1 ] ; then

--- a/windows/src/Executor.cs
+++ b/windows/src/Executor.cs
@@ -48,7 +48,7 @@ namespace Net.XpFramework.Runner
             //                       | USE_XP
             //                       Dot
             string argv = String.Format(
-                "-C -q -dinclude_path=\".{1}{0}{1}{1}{2}\" -dmagic_quotes_gpc=0",
+                "-C -q -dinclude_path=\".{1}{0}{1}{1}{2}\" -dmagic_quotes_gpc=0 -ddisplay_errors=stderr",
                 String.Join(PATH_SEPARATOR, new List<string>(use_xp).ToArray()),
                 PATH_SEPARATOR,
                 String.Join(PATH_SEPARATOR, includes)


### PR DESCRIPTION
I have installed XP on stock Windows7, and it took an eternity to find out that ```xp -v``` would not succeed be related to this error:

```
alex@seventwo [05:30:52] [~/dev/xp-runners] [master *]
-> % xp -v
Fatal error: [xp::core] date.timezone not configured properly. in C:\cw\home\alex\dev\xp.public\core\src\main\php\lang.base.php on line241
```

This took so long, because PHP would not report any error, due to the fact that I installed PHP by .msi-Installer, which provides a "production ready" php.ini setting - this includes *not* reporting errors.

To prevent future cases as this, we could always provide ```-ddisplay_errors=stderr```.