### PR TITLE
Fix System.NullReferenceException

### DIFF
--- a/windows/Makefile
+++ b/windows/Makefile
@@ -36,5 +36,5 @@ xpi.exe: src\\Xpi.cs $(CLASSES)
 	$(CSC) $(CSC_OPT) /out:$@ src\\Xpi.cs $(CLASSES)
 
 clean:
-	-rm xp.exe xpcli.exe xar.exe unittest.exe cgen.exe doclet.exe xcc.exe xpi.exe
+	-rm xp.exe xpcli.exe xpws.exe xar.exe unittest.exe cgen.exe doclet.exe xcc.exe xpi.exe
 

--- a/windows/src/Executor.cs
+++ b/windows/src/Executor.cs
@@ -81,9 +81,13 @@ namespace Net.XpFramework.Runner
             }
 
             // Add extensions
-            foreach (var ext in configs.GetExtensions(runtime))
+            IEnumerable<string> extensions= configs.GetExtensions(runtime);
+            if (null != extensions)
             {
-                argv += " -dextension=" + ext;
+              foreach (var ext in extensions)
+              {
+                  argv += " -dextension=" + ext;
+              }
             }
 
             // Spawn runtime


### PR DESCRIPTION
This pull request fixes the  System.NullReferenceException error when no 'extension' entry is defined in the "[runtime]" section in xp.ini
- See: https://github.com/xp-forge/xp-maven-plugin/issues/2

Regards,
Cosmin
