### PR TITLE
Inspect web configuration

### DIFF
--- a/windows/src/XpWs.cs
+++ b/windows/src/XpWs.cs
@@ -47,7 +47,7 @@ namespace Net.XpFramework.Runner
         static int Inspect(string profile, string server, string port, string root)
         {
             Execute("class", "xp.scriptlet.Inspect", new string[] { "." }, new string[] {
-                root,
+                ".",
                 profile,
                 server + ":" + port
             });


### PR DESCRIPTION
This pull request implement "-i" command line options which lets user inspect web configuration on the command line.

Example output:

``` sh
friebe@thekid ~/devel/dialog [master]
$ xpws localhost:8080 -i -p prod
xpws-prod @ localhost:8080, D:\cygwin\home\friebe\devel\dialog {
  Route</rss/*> => xp.scriptlet.WebApplication(rss)@{
    [config       ] {WEBROOT}/etc
    [scriptlet    ] de.thekid.dialog.scriptlet.RssScriptlet
    [debug        ] NONE
    [arguments    ] [{WEBROOT}/data/]
    [environment  ] [
    ]
  }
  Route</*> => xp.scriptlet.WebApplication(dialog)@{
    [config       ] {WEBROOT}/etc
    [scriptlet    ] de.thekid.dialog.scriptlet.WebsiteScriptlet
    [debug        ] NONE
    [arguments    ] [de.thekid.dialog.scriptlet, {WEBROOT}/xsl]
    [environment  ] [
      DEF_PROD => "dialog"
      DEF_LANG => "en_US"
      DEF_STATE => "static"
    ]
  }
}
```

This pull request depends on `xp.scriptlet.Inspect` in XP Framework - see separate pull request.
