### PR TITLE
Invoke command using shell builtin `exec`

### DIFF
--- a/unix/src/exec.in
+++ b/unix/src/exec.in
@@ -1,3 +1,3 @@
 #include <instance.in>
 
-${XP_EXE}${ifs}${args}${ifs}$tool ${ARGS} "$@"
+exec ${XP_EXE}${ifs}${args}${ifs}$tool ${ARGS} "$@"


### PR DESCRIPTION
This pull requests fixes running commands in a process management environment as eg. `supervisord`, but not forking children, but replacing the runner process with the `php` process.
