### PR TITLE
XPWS Daemonize

### DIFF
--- a/unix/src/xpws.in
+++ b/unix/src/xpws.in
@@ -46,7 +46,7 @@ while [ $# != 0 ]; do
       TOOL='xp.scriptlet.Inspect|${WEB_ROOT}|${WEB_CONFIG}|${SERVER_PROFILE}|${ADDR}'
       shift 1
       ;;
-    start|stop|status)
+    start|stop|status|serve)
       ACTION=$1
       shift 1
       ;;

--- a/unix/src/xpws.in
+++ b/unix/src/xpws.in
@@ -8,6 +8,7 @@ WEB_ROOT=.
 WEB_CONFIG=etc
 ACTION=serve
 PIDFILE="$HOME/.xpws.pid"
+REDIR=
 
 while [ $# != 0 ]; do
   case $1 in
@@ -29,6 +30,11 @@ while [ $# != 0 ]; do
       ;;
     -w)
       WEB_ROOT=$2
+      shift 2
+      ;;
+    -l)
+      REDIR="1>$2 2>&1"
+      touch $2 || exit
       shift 2
       ;;
     -cp)
@@ -114,7 +120,7 @@ else
   export SERVER_PROFILE
   export DOCUMENT_ROOT
 
-  ${XP_EXE}${ifs}-S${ifs}${ADDR}${ifs}-t${ifs}"${DOCUMENT_ROOT}"${ifs}-duser_dir="$WEB_CONFIG"${ifs}${args}${ifs}$tool ${ARGS} "$@" &
+  ${XP_EXE}${ifs}-S${ifs}${ADDR}${ifs}-t${ifs}"${DOCUMENT_ROOT}"${ifs}-duser_dir="$WEB_CONFIG"${ifs}${args}${ifs}$tool ${ARGS} "$@" $REDIR &
   PID=$!
 
   if [ serve = $ACTION ] ; then

--- a/unix/src/xpws.in
+++ b/unix/src/xpws.in
@@ -6,6 +6,8 @@ INCLUDE_PATH="."
 SERVER_PROFILE=dev
 WEB_ROOT=.
 WEB_CONFIG=etc
+ACTION=serve
+PIDFILE=.xpws.pid
 
 while [ $# != 0 ]; do
   case $1 in
@@ -44,6 +46,10 @@ while [ $# != 0 ]; do
       WEB_CONFIG=?
       break
       ;;
+    start|stop|status)
+      ACTION=$1
+      break
+      ;;
     *:*)
       server=${1%:*}
       port=${1#*:}
@@ -71,6 +77,24 @@ fi
 
 if [ $RUNNER = class ] ; then
   ${XP_EXE}${ifs}${args}${ifs}$tool ${ARGS} "$@"
+elif [ $ACTION = status ] ; then
+  if [ -f $PIDFILE ] ; then
+    echo "[xpws-$(cat $PIDFILE)] running $(realpath $PIDFILE)"
+  else
+    echo "xpws not running"
+    exit 1
+  fi
+elif [ $ACTION = stop ] ; then
+  if [ -f $PIDFILE ] ; then
+    running=$(cat $PIDFILE)
+    PID=${running#*'#'}
+    echo "[xpws-$running] shutting down..."
+    kill -TERM $PID
+    rm $PIDFILE
+  else
+    echo "*** xpws not running"
+    exit 1
+  fi
 else
   if [ "" = "$DOCUMENT_ROOT" ] ; then
     if [ -d "$WEB_ROOT/static" ] ; then
@@ -88,8 +112,14 @@ else
 
   ${XP_EXE}${ifs}-S${ifs}${ADDR}${ifs}-t${ifs}"${DOCUMENT_ROOT}"${ifs}-duser_dir="$WEB_CONFIG"${ifs}${args}${ifs}$tool ${ARGS} "$@" &
   PID=$!
-  echo "[xpws-$SERVER_PROFILE#$PID] running $ADDR @ $WEB_ROOT - Press <Enter> to exit"
-  read enter
-  echo "[xpws-$SERVER_PROFILE#$PID] shutting down..."
-  kill -TERM $PID
+
+  if [ serve = $ACTION ] ; then
+    echo "[xpws-$SERVER_PROFILE#$PID] running $ADDR @ $WEB_ROOT - Press <Enter> to exit"
+    read enter
+    echo "[xpws-$SERVER_PROFILE#$PID] shutting down..."
+    kill -TERM $PID
+  else
+    echo "[xpws-$SERVER_PROFILE#$PID] running $ADDR @ $WEB_ROOT - Use xpws stop to end"
+    echo $SERVER_PROFILE#$PID > $PIDFILE
+  fi
 fi

--- a/unix/src/xpws.in
+++ b/unix/src/xpws.in
@@ -7,7 +7,7 @@ SERVER_PROFILE=dev
 WEB_ROOT=.
 WEB_CONFIG=etc
 ACTION=serve
-PIDFILE=.xpws.pid
+PIDFILE="$HOME/.xpws.pid"
 
 while [ $# != 0 ]; do
   case $1 in
@@ -78,24 +78,24 @@ fi
 if [ $RUNNER = class ] ; then
   ${XP_EXE}${ifs}${args}${ifs}$tool ${ARGS} "$@"
 elif [ $ACTION = status ] ; then
-  if [ -f $PIDFILE ] ; then
-    echo "[xpws-$(cat $PIDFILE)] running $(realpath $PIDFILE)"
+  if [ -f "$PIDFILE" ] ; then
+    echo "[xpws-"$(cat "$PIDFILE")"] running "$(realpath "$PIDFILE")
   else
     echo "xpws not running"
     exit 1
   fi
 elif [ $ACTION = stop ] ; then
-  if [ -f $PIDFILE ] ; then
-    running=$(cat $PIDFILE)
+  if [ -f "$PIDFILE" ] ; then
+    running=$(cat "$PIDFILE")
     PID=${running#*'#'}
     echo "[xpws-$running] shutting down..."
     kill -TERM $PID
-    rm $PIDFILE
+    rm "$PIDFILE"
   else
     echo "*** xpws not running"
     exit 1
   fi
-elif [ -f $PIDFILE ] ; then
+elif [ -f "$PIDFILE" ] ; then
   echo "*** xpws already running"
   exit 255
 else
@@ -124,6 +124,6 @@ else
     kill -TERM $PID
   else
     echo "[xpws-$SERVER_PROFILE#$PID] running $ADDR @ $WEB_ROOT - Use xpws stop to end"
-    echo $SERVER_PROFILE#$PID > $PIDFILE
+    echo $SERVER_PROFILE#$PID > "$PIDFILE"
   fi
 fi

--- a/unix/src/xpws.in
+++ b/unix/src/xpws.in
@@ -35,20 +35,20 @@ while [ $# != 0 ]; do
       INCLUDE_PATH=${INCLUDE_PATH}${PATHSEP}$2
       shift 2
       ;;
-    -i)
-      RUNNER=class
-      TOOL='xp.scriptlet.Inspect|${WEB_ROOT}|${WEB_CONFIG}|${SERVER_PROFILE}|${ADDR}'
-      shift 1
-      ;;
     -?)
       RUNNER=class
       TOOL="xp.scriptlet.Usage|xpws.txt"
       WEB_CONFIG=?
       break
       ;;
+    info)
+      RUNNER=class
+      TOOL='xp.scriptlet.Inspect|${WEB_ROOT}|${WEB_CONFIG}|${SERVER_PROFILE}|${ADDR}'
+      shift 1
+      ;;
     start|stop|status)
       ACTION=$1
-      break
+      shift 1
       ;;
     *:*)
       server=${1%:*}

--- a/unix/src/xpws.in
+++ b/unix/src/xpws.in
@@ -95,7 +95,11 @@ elif [ $ACTION = stop ] ; then
     echo "*** xpws not running"
     exit 1
   fi
+elif [ -f $PIDFILE ] ; then
+  echo "*** xpws already running"
+  exit 255
 else
+
   if [ "" = "$DOCUMENT_ROOT" ] ; then
     if [ -d "$WEB_ROOT/static" ] ; then
       DOCUMENT_ROOT="$WEB_ROOT/static"

--- a/windows/src/XpWs.cs
+++ b/windows/src/XpWs.cs
@@ -1,6 +1,7 @@
 using System;
 using System.IO;
 using System.Collections.Generic;
+using System.Diagnostics;
 
 namespace Net.XpFramework.Runner
 {
@@ -8,11 +9,8 @@ namespace Net.XpFramework.Runner
     {
         delegate int Execution(string profile, string server, string port, string web, string root, string config, string[] inc);
 
-        /// Delegate: Serve web
-        static int Serve(string profile, string server, string port, string web, string root, string config, string[] inc)
+        protected static Process NewProcess(string profile, string server, string port, string web, string root, string config, string[] inc)
         {
-            var pid = System.Diagnostics.Process.GetCurrentProcess().Id;
-
             // If no document root has been supplied, check for an existing "static"
             // subdirectory inside the web root; otherwise just use the web roor
             if (String.IsNullOrEmpty(root))
@@ -34,16 +32,23 @@ namespace Net.XpFramework.Runner
                 proc.StartInfo.Arguments
             );
 
+            Environment.SetEnvironmentVariable("WEB_ROOT", web);
+            Environment.SetEnvironmentVariable("SERVER_PROFILE", profile);
+            Environment.SetEnvironmentVariable("DOCUMENT_ROOT", root);
+
+            return proc;
+        }
+
+        /// Delegate: Serve web
+        static int Serve(string profile, string server, string port, string web, string root, string config, string[] inc)
+        {
+            var proc = NewProcess(profile, server, port, web, root, config, inc);
             try
             {
-                Environment.SetEnvironmentVariable("WEB_ROOT", web);
-                Environment.SetEnvironmentVariable("SERVER_PROFILE", profile);
-                Environment.SetEnvironmentVariable("DOCUMENT_ROOT", root);
-
                 proc.Start();
-                Console.Out.WriteLine("[xpws-{0}#{1}] running {2}:{3} @ {4} - Press <Enter> to exit", profile, pid, server, port, web);
+                Console.Out.WriteLine("[xpws-{0}#{1}] running {2}:{3} @ {4} - Press <Enter> to exit", profile, proc.Id, server, port, web);
                 Console.Read();
-                Console.Out.WriteLine("[xpws-{0}#{1}] shutting down...", profile, pid);
+                Console.Out.WriteLine("[xpws-{0}#{1}] shutting down...", profile, proc.Id);
                 proc.Kill();
                 proc.WaitForExit();
                 return proc.ExitCode;
@@ -52,6 +57,94 @@ namespace Net.XpFramework.Runner
             {
                 Console.Error.WriteLine("*** " + proc.StartInfo.FileName + ": " + e.Message);
                 return 0xFF;
+            }
+            finally
+            {
+                proc.Close();
+            }
+        }
+
+        protected static string PidFile()
+        {
+            return Paths.Compose(Environment.GetFolderPath(Environment.SpecialFolder.Personal), ".xpws.pid");
+        }
+
+        /// Delegate: Start serving web
+        static int Start(string profile, string server, string port, string web, string root, string config, string[] inc)
+        {
+            var proc = NewProcess(profile, server, port, web, root, config, inc);
+            try
+            {
+                proc.Start();
+
+                // Write PID file and exit
+                File.WriteAllText(PidFile(), profile + '#' + proc.Id);
+                Console.Out.WriteLine("[xpws-{0}#{1}] running {2}:{3} @ {4} - Use xpws stop to end", profile, proc.Id, server, port, web);
+                return 0;
+            }
+            catch (SystemException e)
+            {
+                Console.Error.WriteLine("*** " + proc.StartInfo.FileName + ": " + e.Message);
+                return 0xFF;
+            }
+            finally
+            {
+                proc.Close();
+            }
+        }
+
+        /// Delegate: Stop serving web
+        static int Status(string profile, string server, string port, string web, string root, string config, string[] inc)
+        {
+            var pidFile = PidFile();
+
+            if (!File.Exists(pidFile))
+            {
+                Console.WriteLine("xpws not running");
+                return 1;
+            }
+            else
+            {
+                Console.WriteLine("[xpws-{0}] running {1}", File.ReadAllText(pidFile).Trim(), pidFile);
+                return 0;
+            }
+        }
+
+        /// Delegate: Stop serving web
+        static int Stop(string profile, string server, string port, string web, string root, string config, string[] inc)
+        {
+            var pidFile = PidFile();
+
+            if (!File.Exists(pidFile))
+            {
+                Console.Error.WriteLine("*** xpws not running");
+                return 0xFF;
+            }
+
+            // Parse pid file, then delete it
+            var spec = File.ReadAllText(pidFile).Trim().Split('#');
+            var running = spec[0];
+            var pid = Convert.ToInt32(spec[1]);
+            File.Delete(pidFile);
+
+            // Close process
+            Process proc = null;
+            try
+            {
+                proc = Process.GetProcessById(pid);
+            }
+            catch (ArgumentException e)
+            {
+                Console.Error.WriteLine("*** Cannot shut down xpws: " + e.Message);
+                return 0xFF;
+            }
+
+            try
+            {
+                Console.Out.WriteLine("[xpws-{0}#{1}] shutting down...", running, pid);
+                proc.Kill();
+                proc.WaitForExit();
+                return 0;
             }
             finally
             {
@@ -121,6 +214,18 @@ namespace Net.XpFramework.Runner
                     case "-?":
                         Execute("class", "xp.scriptlet.Usage", inc.ToArray(), new string[] { "xpws.txt" });
                         return;
+
+                    case "start":
+                        action = Start;
+                        break;
+
+                    case "status":
+                        action = Status;
+                        break;
+
+                    case "stop":
+                        action = Stop;
+                        break;
 
                     default:
                         addr = args[i].Split(':');

--- a/windows/src/XpWs.cs
+++ b/windows/src/XpWs.cs
@@ -224,13 +224,13 @@ namespace Net.XpFramework.Runner
                         inc.Add(Paths.Resolve(args[++i]));
                         break;
 
-                    case "-i":
-                        action = Inspect;
-                        break;
-
                     case "-?":
                         Execute("class", "xp.scriptlet.Usage", inc.ToArray(), new string[] { "xpws.txt" });
                         return;
+
+                    case "info":
+                        action = Inspect;
+                        break;
 
                     case "start":
                         action = Start;

--- a/windows/src/XpWs.cs
+++ b/windows/src/XpWs.cs
@@ -66,7 +66,7 @@ namespace Net.XpFramework.Runner
 
         protected static string PidFile()
         {
-            return Paths.Compose(Environment.GetFolderPath(Environment.SpecialFolder.Personal), ".xpws.pid");
+            return Paths.Compose(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), ".xpws.pid");
         }
 
         /// Delegate: Start serving web

--- a/windows/src/XpWs.cs
+++ b/windows/src/XpWs.cs
@@ -232,6 +232,10 @@ namespace Net.XpFramework.Runner
                         action = Inspect;
                         break;
 
+                    case "serve":
+                        action = Serve;
+                        break;
+
                     case "start":
                         action = Start;
                         break;


### PR DESCRIPTION
This pull request adds Un*x daemon control features to `xpws`:

```sh
$ xpws start
[xpws-dev#3724] running localhost:8080 @ C:\cygwin\home\friebe\devel\rest-file-upload - Use xpws stop to end

$ curl http://localhost:8080/
# ...

$ xpws status
[xpws-dev#3724] running C:\Users\friebe\AppData\Local\.xpws.pid

$ xpws stop
[xpws-dev#3724] shutting down...
```

The usage is:

```
Usage:
========================================================================
  xpws [verb] [options] [host[:port]]
========================================================================

Verb is one of:

  * serve  : Start an interactive session (shut down using <Enter>)
  * start  : Start the daemon
  * status : Query whether the daemon is running
  * info   : Inspect web configuration only, do no start the server
  * stop   : Stop the daemon

If omitted, the interactive session will be started. Options to starting
the server is any of:

  * -w <path>    : Specify web root. Defaults to "."
  * -c <path>    : Specify configuration directory. Defaults to "./etc"
  * -r <path>    : Specify document root. Defaults to "./static"
  * -p <profile> : Set SERVER_PROFILE. Defaults to "dev"
  * -cp <path>   : Add class path entry.

Host and port default to "localhost:8080".
