### PR TITLE
Allow starting without web config

### DIFF
--- a/unix/src/xpws.in
+++ b/unix/src/xpws.in
@@ -65,8 +65,7 @@ EXEC($RUNNER, $INCLUDE_PATH, $TOOL)
 #include <instance.in>
 
 if [ $WEB_CONFIG != "?" ] && [ ! -e "$WEB_CONFIG/web.ini" ] ; then
-  echo "*** Cannot find the web configuration web.ini in $WEB_CONFIG/, exiting." >&2
-  exit 3
+  echo "No configuration file in $WEB_CONFIG, using defaults"
 fi
 
 if [ $RUNNER = class ] ; then

--- a/windows/src/XpWs.cs
+++ b/windows/src/XpWs.cs
@@ -143,8 +143,7 @@ namespace Net.XpFramework.Runner
             // Verify we have a web.ini
             if (!File.Exists(Paths.Compose(config, "web.ini")))
             {
-                Console.Error.WriteLine("*** Cannot find the web configuration web.ini in {0}/, exiting.", config);
-                Environment.Exit(0x03);
+                Console.WriteLine("No configuration file in {0}, using defaults", config);
             }
 
             // Run


### PR DESCRIPTION
This pull request makes a non-existant `etc/web.ini` no longer a reason for bailing before startup. It can perfectly make sense, e.g. to simply start serving static contents:

``` sh
$ find . | grep -v .git
.
./README.md
./static
./static/index.html

$ xpws
# now open http://localhost:8080/index.html
```
