### PR TITLE
Unittest watcher

### DIFF
--- a/unix/src/unittest.in
+++ b/unix/src/unittest.in
@@ -2,4 +2,21 @@
 
 EXEC("class", ".", xp.unittest.Runner)
 
-#include <exec.in> 
+#include <instance.in>
+
+if getopts :w: watch ; then
+  ${XP_EXE}${ifs}${args}${ifs}$tool ${ARGS} "$@"
+
+  if [ $? = 2 ] ; then
+    exit 2
+  elif [ $? = 126 ] || [ $? = 127 ] ; then
+    exit 255
+  fi
+
+  inotifywait -q -e close_write -m -r $OPTARG | while read event
+  do
+    ${XP_EXE}${ifs}${args}${ifs}$tool ${ARGS} "$@"
+  done
+else
+  exec ${XP_EXE}${ifs}${args}${ifs}$tool ${ARGS} "$@"
+fi

--- a/windows/src/Unittest.cs
+++ b/windows/src/Unittest.cs
@@ -7,43 +7,52 @@ namespace Net.XpFramework.Runner
     class Unittest : BaseRunner
     {
 
+        /// Runs the command and returns the exitcode
+        private static int Run(string[] args)
+        {
+            try
+            {
+                return Executor.Execute(Paths.DirName(Paths.Binary()), "class", "xp.unittest.Runner", new string[] { "." }, args);
+            }
+            catch (Exception e) 
+            {
+                Console.Error.WriteLine("*** " + e.GetType() + ": " + e.Message);
+                return -1;
+            }
+        }
+
         static void Main(string[] args)
         {
             var watch = Array.IndexOf(args, "-w");
             if (watch < 0)
             {
-                Execute("class", "xp.unittest.Runner", new string[] { "." }, args);
+                Environment.Exit(Run(args));
             }
             else
             {
-                var remaining = new string[args.Length - 2];
-                Array.Copy(args, remaining, watch);
-                Array.Copy(args, watch + 2, remaining, watch, args.Length - watch - 2);
+                // First run may not exit with a startup or argument error
+                var code = Run(args);
+                if (-1 == code)
+                {
+                    Environment.Exit(0xFF);
+                }
+                else if (2 == code)
+                {
+                    Environment.Exit(2);
+                }
 
                 var watcher = new FileSystemWatcher {
                   Path = args[watch + 1],
                   IncludeSubdirectories = true,
                   Filter = "*.*"
                 };
-
                 using (watcher) 
                 {
                     watcher.EnableRaisingEvents = true;
-
-                    do
+                    while (!watcher.WaitForChanged(WatcherChangeTypes.Changed).TimedOut)
                     {
-                        try
-                        {
-                            Executor.Execute(Paths.DirName(Paths.Binary()), "class", "xp.unittest.Runner", new string[] { "." }, remaining);
-                        }
-                        catch (Exception e) 
-                        {
-                            Console.Error.WriteLine("*** " + e.GetType() + ": " + e.Message);
-                            Environment.Exit(0xFF);
-                        }
-
-                        watcher.WaitForChanged(WatcherChangeTypes.Changed);
-                    } while (true);
+                        Run(args);
+                    }
                 }
                 Environment.Exit(0);
             }

--- a/windows/src/Unittest.cs
+++ b/windows/src/Unittest.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.IO;
 using System.Collections.Generic;
 
 namespace Net.XpFramework.Runner
@@ -8,7 +9,44 @@ namespace Net.XpFramework.Runner
 
         static void Main(string[] args)
         {
-            Execute("class", "xp.unittest.Runner", new string[] { "." }, args);
+            var watch = Array.IndexOf(args, "-w");
+            if (watch < 0)
+            {
+                Execute("class", "xp.unittest.Runner", new string[] { "." }, args);
+            }
+            else
+            {
+                var remaining = new string[args.Length - 2];
+                Array.Copy(args, remaining, watch);
+                Array.Copy(args, watch + 2, remaining, watch, args.Length - watch - 2);
+
+                var watcher = new FileSystemWatcher {
+                  Path = args[watch + 1],
+                  IncludeSubdirectories = true,
+                  Filter = "*.*"
+                };
+
+                using (watcher) 
+                {
+                    watcher.EnableRaisingEvents = true;
+
+                    do
+                    {
+                        try
+                        {
+                            Executor.Execute(Paths.DirName(Paths.Binary()), "class", "xp.unittest.Runner", new string[] { "." }, remaining);
+                        }
+                        catch (Exception e) 
+                        {
+                            Console.Error.WriteLine("*** " + e.GetType() + ": " + e.Message);
+                            Environment.Exit(0xFF);
+                        }
+
+                        watcher.WaitForChanged(WatcherChangeTypes.Changed);
+                    } while (true);
+                }
+                Environment.Exit(0);
+            }
         }
     }
 }


### PR DESCRIPTION
This adds a new command line option to the unittest runner, `-w`.

```
-w {dir}: Run indefinitely, watch given directory for changes
```

The framework needs to adapt slighty - see https://github.com/xp-framework/core/pull/75. 

For XP 5, the only thing that happens is:

```sh
$ USE_XP=../xp-5x/core unittest -w . -?
*** Class "-w" could not be found
```

...but the changes could of course be easily backported there, too (@kiesel - might be interesting for XP 5.11 which you're currently planning?)