### PR TITLE
Fix triggering watch mode

### DIFF
--- a/unix/src/unittest.in
+++ b/unix/src/unittest.in
@@ -4,7 +4,15 @@ EXEC("class", ".", xp.unittest.Runner)
 
 #include <instance.in>
 
-if getopts :w: watch ; then
+WATCH=""
+
+while getopts :w: flag ; do
+  case "$flag" in
+    w) WATCH="$OPTARG"; shift 1 ;;
+  esac
+done
+
+if [ -n "$WATCH" ] ; then
   ${XP_EXE}${ifs}${args}${ifs}$tool ${ARGS} "$@"
 
   if [ $? = 2 ] ; then
@@ -13,7 +21,7 @@ if getopts :w: watch ; then
     exit 255
   fi
 
-  inotifywait -q -e close_write -m -r $OPTARG | while read event
+  inotifywait -q -e close_write -m -r $WATCH | while read event
   do
     ${XP_EXE}${ifs}${args}${ifs}$tool ${ARGS} "$@"
   done


### PR DESCRIPTION
Shell builtin `getopts` signals success whenever there is an
argument to parse (that looks like an option starting with "-"). So,
previously a command `unittest -q ...` would trigger getopts and lead
`unittest` to enter the watch mode branch.

This commit fixes that by testing for the actual option detected by
getopts.