### PR TITLE
Support optional class path entries via ?[path]

### DIFF
--- a/test/shared/scan-path-test.php
+++ b/test/shared/scan-path-test.php
@@ -169,6 +169,14 @@ exit($test->run([
     );
   },
 
+  'non-existant entries with question marks are ok' => function() use($path) {
+    file_put_contents($path->compose($this->classpath, 'class.pth'), '?does-not-exist');
+    $this->assertEquals(
+      [],
+      \xp\scan([$this->classpath], $this->home)
+    );
+  },
+
   'supports ~ in include path' => function() use($path) {
     $xar= $path->compose($this->home, 'core.xar');
     file_put_contents($path->compose($this->classpath, 'class.pth'), $xar);


### PR DESCRIPTION
For example, `?vendor/autoload.php` - XP tools executed in the directory will not barf if composer has not yet been run this way.