### PR TITLE
Implement running .xar files directly without xp.runtime.Xar

### DIFF
--- a/shared/src/class-main.php
+++ b/shared/src/class-main.php
@@ -93,6 +93,15 @@ if (strpos($argv[0], \xp::CLASS_FILE_EXT)) {
     throw new \Exception('Cannot load '.$argv[0].' - not in class path');
   }
   $class= $cl->loadUri($uri);
+} else if (0 === substr_compare($argv[0], '.xar', -4, 4)) {
+  if (false === ($uri= realpath($argv[0]))) {
+    throw new \Exception('Cannot load '.$argv[0].' - does not exist');
+  }
+  $cl= \lang\ClassLoader::registerPath($uri);
+  if (!$cl->providesResource('META-INF/manifest.ini')) {
+    throw new \Exception($cl->toString().' does not provide a manifest');
+  }
+  $class= $cl->loadClass(parse_ini_string($cl->getResource('META-INF/manifest.ini'))['main-class']);
 } else {
   $class= \lang\ClassLoader::getDefault()->loadClass($argv[0]);
 }

--- a/shared/src/class-main.php
+++ b/shared/src/class-main.php
@@ -85,7 +85,8 @@ foreach ($include as $path => $_) {
   \lang\ClassLoader::registerPath($path);
 }
 
-if (strpos($argv[0], \xp::CLASS_FILE_EXT)) {
+$ext= substr($argv[0], -4, 4);
+if ('.php' === $ext) {
   if (false === ($uri= realpath($argv[0]))) {
     throw new \Exception('Cannot load '.$argv[0].' - does not exist');
   }
@@ -93,7 +94,7 @@ if (strpos($argv[0], \xp::CLASS_FILE_EXT)) {
     throw new \Exception('Cannot load '.$argv[0].' - not in class path');
   }
   $class= $cl->loadUri($uri);
-} else if (0 === substr_compare($argv[0], '.xar', -4, 4)) {
+} else if ('.xar' === $ext) {
   if (false === ($uri= realpath($argv[0]))) {
     throw new \Exception('Cannot load '.$argv[0].' - does not exist');
   }


### PR DESCRIPTION
Runs class file if it is in class path

```sh
$ xp [run] test.xar
```

*Will be supported in current and new runners seamlessly, but not work in XP5, which still bundles the entry point class.php, unless it's upgraded to 5.12.0. This will result in XP runners, 6.2.0.*

See xp-runners/reference#6