### PR TITLE
Remove loop over $include which was removed

### DIFF
--- a/shared/src/web-main.php
+++ b/shared/src/web-main.php
@@ -48,10 +48,6 @@ ini_set('error_prepend_string', '<xmp>');
 ini_set('error_append_string', '</xmp>');
 ini_set('html_errors', 0);
 
-foreach ($include as $path => $_) {
-  \lang\ClassLoader::registerPath($path);
-}
-
 try {
   exit(\xp\scriptlet\Runner::main(array($home, $config, $_SERVER['SERVER_PROFILE'], $_SERVER['SCRIPT_URL'])));
 } catch (\lang\SystemExit $e) {


### PR DESCRIPTION
The $include variable has been removed in commit
09f99daf1351f6e3ed5c228b7ed8bff25e37454e which was included in PR #39,
but this spot seems to have been missed.

This causes fatal errors during bootstrapping for web apps.