### PR TITLE
Default argument encoding to utf-7.

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,7 +1,14 @@
 XP Runners ChangeLog
 ========================================================================
 
-## 6.3.0 / 2016-01-10
+## 6.4.0 / 2016-06-04
+
+* Made argument encoding compatible with new XP runners: The default is
+  to encode them binary-safe using `utf-7`. Only difference: Passing "no"
+  as encoding value will prevent any decoding from happening.
+  (@thekid)
+
+## 6.3.1 / 2016-01-10
 
 * Merged PR #39: Refactor bootstrapping to match precedence definitions
   (@thekid)

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -4,8 +4,8 @@ XP Runners ChangeLog
 ## 6.4.0 / 2016-06-04
 
 * Made argument encoding compatible with new XP runners: The default is
-  to encode them binary-safe using `utf-7`. Only difference: Passing "no"
-  as encoding value will prevent any decoding from happening.
+  to encode them binary-safe using `utf-7`. Only difference: Passing
+  "utf-8" as encoding value will prevent any decoding from happening.
   (@thekid)
 
 ## 6.3.1 / 2016-01-10

--- a/setup
+++ b/setup
@@ -4,7 +4,7 @@
  * $Id$
  */
 
-  define('BASE_URL',   'https://github.com/xp-framework/xp-runners/releases/download/v6.3.0/');
+  define('BASE_URL',   'https://github.com/xp-framework/xp-runners/releases/download/v6.4.0/');
 
   // {{{ println(string* args)
   function println() {
@@ -16,7 +16,7 @@
   // {{{ ardl(string proxy, string url, string targetdir)
   function ardl($proxy, $url, $targetdir, $permissions= -1) {
     static $pw= 10;
-    static $headers= "User-Agent: xp-setup/6.3.0\r\nAccept: */*\r\n\r\n";
+    static $headers= "User-Agent: xp-setup/6.4.0\r\nAccept: */*\r\n\r\n";
 
     do {
       if ($proxy) {

--- a/shared/src/class-main.php
+++ b/shared/src/class-main.php
@@ -74,7 +74,7 @@ require 'class-path.php';
 PHP_VERSION < '5.6' && iconv_set_encoding('internal_encoding', \xp::ENCODING);
 array_shift($_SERVER['argv']);
 array_shift($argv);
-if (get_cfg_var('encoding')) foreach ($argv as $i => $val) {
+if ('no' !== get_cfg_var('encoding')) foreach ($argv as $i => $val) {
   $_SERVER['argv'][$i]= $argv[$i]= iconv('utf-7', \xp::ENCODING, $val);
 }
 

--- a/shared/src/class-main.php
+++ b/shared/src/class-main.php
@@ -75,7 +75,8 @@ PHP_VERSION < '5.6' && iconv_set_encoding('internal_encoding', \xp::ENCODING);
 array_shift($_SERVER['argv']);
 array_shift($argv);
 if (\xp::ENCODING !== get_cfg_var('encoding')) foreach ($argv as $i => $val) {
-  $_SERVER['argv'][$i]= $argv[$i]= iconv('utf-7', \xp::ENCODING, $val);
+  $decoded= iconv('utf-7', \xp::ENCODING, $val);
+  $_SERVER['argv'][$i]= $argv[$i]= false === $decoded ? $val : $decoded;
 }
 
 $ext= substr($argv[0], -4, 4);

--- a/shared/src/class-main.php
+++ b/shared/src/class-main.php
@@ -74,7 +74,7 @@ require 'class-path.php';
 PHP_VERSION < '5.6' && iconv_set_encoding('internal_encoding', \xp::ENCODING);
 array_shift($_SERVER['argv']);
 array_shift($argv);
-if ('no' !== get_cfg_var('encoding')) foreach ($argv as $i => $val) {
+if (\xp::ENCODING !== get_cfg_var('encoding')) foreach ($argv as $i => $val) {
   $_SERVER['argv'][$i]= $argv[$i]= iconv('utf-7', \xp::ENCODING, $val);
 }
 

--- a/test/runners/xp6-runner-test.php
+++ b/test/runners/xp6-runner-test.php
@@ -25,6 +25,8 @@ exit($test->run(array_merge($base, [
   },
 
   'uncaught throwables' => function() use($path, $proc) {
+    if (defined('HHVM_VERSION')) return;
+
     $result= $proc->execute($this->exe, ['-e', '"throw new \lang\Error(\"Test\")"'], $this->env, $this->tmp);
     $this->assertEquals(255, key($result));
     $this->assertEquals(true, (bool)preg_grep('/Uncaught exception/', current($result)));

--- a/test/runners/xp6-runner-test.php
+++ b/test/runners/xp6-runner-test.php
@@ -25,8 +25,6 @@ exit($test->run(array_merge($base, [
   },
 
   'uncaught throwables' => function() use($path, $proc) {
-    if (defined('HHVM_VERSION')) return;
-
     $result= $proc->execute($this->exe, ['-e', '"throw new \lang\Error(\"Test\")"'], $this->env, $this->tmp);
     $this->assertEquals(255, key($result));
     $this->assertEquals(true, (bool)preg_grep('/Uncaught exception/', current($result)));

--- a/unix/src/instance.in
+++ b/unix/src/instance.in
@@ -91,7 +91,7 @@ if [ "" = "$tool" ] ; then
   done
   set -- "${_args[@]}"
 #else
-  args="$args${ifs}-d${ifs}encoding=no"
+  args="$args${ifs}-d${ifs}encoding=utf-8"
 #endif
 fi
 #ifdef __BSD

--- a/unix/src/instance.in
+++ b/unix/src/instance.in
@@ -90,7 +90,8 @@ if [ "" = "$tool" ] ; then
     _args=("${_args[@]}" "$(echo $arg | iconv -f utf-8 -t utf-7)")
   done
   set -- "${_args[@]}"
-  args="$args${ifs}-d${ifs}encoding=utf-7"
+#else
+  args="$args${ifs}-d${ifs}encoding=no"
 #endif
 fi
 #ifdef __BSD

--- a/windows/src/AssemblyInfo.cs
+++ b/windows/src/AssemblyInfo.cs
@@ -7,5 +7,5 @@ using System.Runtime.Versioning;
 [assembly: AssemblyProduct("XP Runners")]
 [assembly: AssemblyTitle("XP Runner")]
 [assembly: AssemblyCopyright("Copyright XP-Framework Team 2001-2016")]
-[assembly: AssemblyVersion("6.3.0.2207")]
+[assembly: AssemblyVersion("6.4.0.1609")]
 [assembly: TargetFramework(".NETFramework,Version=v4.0")]

--- a/windows/src/Executor.cs
+++ b/windows/src/Executor.cs
@@ -156,7 +156,6 @@ namespace Net.XpFramework.Runner
             {
                 argument = Encode;
                 redirect = true;
-                argv += " -d encoding=utf-7";
             }
             else
             {


### PR DESCRIPTION
Forward-compatible with new XP runners. Only difference: Passing `xp::ENCODING` ("utf-8") as encoding value will prevent any decoding from happening
